### PR TITLE
Fix Runway Academy link

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ Build video AI into your products.
 ## Learning Resources
 
 ### Tutorials
-- [Runway Academy](https://runwayml.com/academy) - Official tutorials
+- [Runway Academy](https://academy.runwayml.com/) - Official tutorials
 - [AI Video Course by Dave Clark](https://www.youtube.com/@DaveClark) - YouTube tutorials
 - [Theoretically Media](https://www.youtube.com/@TheoreticallyMedia) - AI video news
 


### PR DESCRIPTION
## Summary
- update the Runway Academy tutorial link from the old 404 URL to the current academy.runwayml.com site

## Validation
- curl -L --max-time 15 https://runwayml.com/academy -> 404
- curl -L --max-time 15 https://academy.runwayml.com/ -> 200
- git diff --check -- README.md
- rg -n "Runway Academy|runwayml.com/academy|academy.runwayml.com" README.md